### PR TITLE
fix strict mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+'use strict';
 module.exports = {
     extends: 'airbnb',
     env: {
@@ -6,10 +7,14 @@ module.exports = {
         node: true,
         mocha: true
     },
+    parserOptions: {
+        sourceType: 'script'
+    },
     rules: {
         'comma-dangle': ['error', 'never'],
         indent: ['error', 4],
         'max-len': ['error', { code: 100, ignoreComments: true }],
+        'new-cap': ['error', { capIsNewExceptions: ['Given', 'When', 'Then'] }],
         'newline-after-var': ['error', 'always'],
         'newline-before-return': 'error',
         'no-bitwise': 'error',
@@ -20,6 +25,7 @@ module.exports = {
                 MethodDefinition: false,
                 ClassDeclaration: false
             }
-        }]
+        }],
+        strict: ['error', 'safe']
     }
 };

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,3 +1,4 @@
+'use strict';
 const assert = require('chai').assert;
 const config = require('../index');
 


### PR DESCRIPTION
`use strict` has errors for odd reasons, especially when running tests. It seems like the parserOptions are defaulting to `module`, thus preventing the check for executing properly.

Also adding definitions for cucumber test keywords so they no longer have `new-cap` errors.
