### PR TITLE
Disable rest/spread operators preferences

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,8 @@ module.exports = {
         'newline-before-return': 'error',
         'no-bitwise': 'error',
         'no-multiple-empty-lines': ['error', { max: 1 }],
+        'prefer-rest-params': 'off',
+        'prefer-spread': 'off',
         'require-jsdoc': ['error', {
             require: {
                 FunctionDeclaration: true,


### PR DESCRIPTION
Rest and spread operators aren't supported in node 4.x, at least not without extra flags to nodejs. Disabling those rules for now.
