### PR TITLE
Update major version of eslint. Remove react/jsx lint plugin dependencies.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 module.exports = {
-    extends: 'airbnb',
+    extends: 'airbnb-base',
     env: {
         browser: true,
         es6: true,
@@ -28,6 +28,12 @@ module.exports = {
                 ClassDeclaration: false
             }
         }],
-        strict: ['error', 'safe']
+        strict: ['error', 'safe'],
+        'import/no-extraneous-dependencies': ['error', {
+            devDependencies: true,
+            optionalDependencies: false,
+            peerDependencies: false
+        }],
+        'import/newline-after-import': ['off']
     }
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-screwdriver",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "ESLint rules for screwdriver projects",
   "main": "index.js",
   "scripts": {
@@ -33,10 +33,8 @@
     "jenkins-mocha": "^2.6.0"
   },
   "dependencies": {
-    "eslint": "^2.10.2",
-    "eslint-config-airbnb": "^9.0.1",
-    "eslint-plugin-import": "^1.8.0",
-    "eslint-plugin-jsx-a11y": "^1.2.2",
-    "eslint-plugin-react": "^5.1.1"
+    "eslint": "^3.2.2",
+    "eslint-config-airbnb-base": "^5.0.1",
+    "eslint-plugin-import": "^1.12.0"
   }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -8,6 +8,6 @@ describe('index test', () => {
     });
 
     it('extends airbnb', () => {
-        assert.equal(config.extends, 'airbnb');
+        assert.equal(config.extends, 'airbnb-base');
     });
 });


### PR DESCRIPTION
We don't have any react/jsx code, so there's no reason to keep having these peer dependencies. We can use airbnb-base.

`import/no-extraneous-dependencies` will error when any file requires a devDependency. Unfortunately, this causes lint to fail when it checks test/feature files. So I've turned it off.

`import/newline-after-import` requires that there is a newline after every `require` statement no followed by another `require`. Stylistically, I'd rather we let the `require`s be used inline with the rest of the variable declaration at the top of the script, so I've turned that off as well.

https://github.com/benmosher/eslint-plugin-import
