### PR TITLE
Turn off class-methods-use-this

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ module.exports = {
     },
     rules: {
         'comma-dangle': ['error', 'never'],
+        'class-methods-use-this': 'off',
         indent: ['error', 4],
         'max-len': ['error', { code: 100, ignoreComments: true }],
         'new-cap': ['error', { capIsNewExceptions: ['Given', 'When', 'Then'] }],


### PR DESCRIPTION
This rule suggests that any class methods that do not use the "this" keyword should be static methods. Turning the rule off for now.
http://eslint.org/docs/rules/class-methods-use-this
