### PR TITLE
fix: Add 'Before' and 'After' to capIsNewExceptions

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ module.exports = {
         'class-methods-use-this': 'off',
         indent: ['error', 4],
         'max-len': ['error', { code: 100, ignoreComments: true }],
-        'new-cap': ['error', { capIsNewExceptions: ['Given', 'When', 'Then'] }],
+        'new-cap': ['error', { capIsNewExceptions: ['Given', 'When', 'Then', 'Before', 'After'] }],
         'newline-after-var': ['error', 'always'],
         'newline-before-return': 'error',
         'no-bitwise': 'error',


### PR DESCRIPTION
`Cucumber` has caps for `Before` and `After` hooks in addition to the 3 that were already excluded.