### PR TITLE
fix: add prettier config for max length

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,7 +66,8 @@ module.exports = {
             'error',
             {
                 singleQuote: true,
-                tabWidth: 4
+                tabWidth: 4,
+                printWidth: 120
             }
         ],
         'require-jsdoc': [


### PR DESCRIPTION
## Context

Default prettier line length is 80. Relax that to 120.

## Objective

Make prettier line length consistent with eslint configured `max-len`

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
