### PR TITLE
fix: rely on prettier `printWidth`  instead of eslint `max-len` to enforce line length

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,6 @@ module.exports = {
                 peerDependencies: false
             }
         ],
-        'max-len': ['error', { code: 120, ignoreComments: true }],
         'max-lines-per-function': 'warn',
         'max-params': 'warn',
         'max-statements': 'warn',


### PR DESCRIPTION

## Context

Let prettier handle line width

## Objective

Remove eslint config for line length

## References

https://github.com/prettier/eslint-config-prettier/blob/master/index.js#L14

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
