### PR TITLE
fix: turn off no-underscore-dangle rule.

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,6 +41,7 @@ module.exports = {
         'no-bitwise': 'error',
         'no-multiple-empty-lines': ['error', { max: 1 }],
         'no-param-reassign': ['error', { props: false }],
+        'no-underscore-dangle': ['off'],
         // Override base rule to remove 'ForOfStatement'
         'no-restricted-syntax': [
             'error',


### PR DESCRIPTION


## Context

We use it extensively in our code base https://github.com/screwdriver-cd/executor-base/blob/master/index.js\#L98


## References

https://cd.screwdriver.cd/pipelines/571/builds/174581/steps/test

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
