### PR TITLE
fix: Semantic release. BREAKING CHANGE: Node16 & Prettier v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,15 +4,14 @@
   "description": "ESLint rules for screwdriver projects",
   "main": "index.js",
   "scripts": {
-    "test": "nyc --report-dir ./artifacts/coverage --reporter=lcov mocha --reporter mocha-multi-reporters --reporter-options configFile=./mocha.config.json --recursive --timeout 4000 --retries 1 --exit --allow-uncaught true --color true",
-    "semantic-release": "semantic-release pre && npm publish && semantic-release post"
+    "test": "nyc --report-dir ./artifacts/coverage --reporter=lcov mocha --reporter mocha-multi-reporters --reporter-options configFile=./mocha.config.json --recursive --timeout 4000 --retries 1 --exit --allow-uncaught true --color true"
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:screwdriver-cd/eslint-config-screwdriver.git"
+    "url": "git+https://github.com/screwdriver-cd/eslint-config-screwdriver.git"
   },
   "homepage": "https://github.com/screwdriver-cd/eslint-config-screwdriver",
-  "bugs": "https://github.com/screwdriver-cd/eslint-config-screwdriver/issues",
+  "bugs": "https://github.com/screwdriver-cd/screwdriver/issues",
   "keywords": [
     "eslint",
     "eslintconfig",
@@ -32,10 +31,7 @@
     "Tiffany Kyi <tiffanykyi@gmail.com>"
   ],
   "release": {
-    "debug": false,
-    "verifyConditions": {
-      "path": "./node_modules/semantic-release/src/lib/plugin-noop.js"
-    }
+    "debug": false
   },
   "peerDependencies": {
     "eslint": ">= 8",


### PR DESCRIPTION
## Context

Need to update package.json for semantic release

## Objective

This PR removes noop package and adds correct checkout url.

## References

Related to https://github.com/screwdriver-cd/eslint-config-screwdriver/pull/52

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
